### PR TITLE
Performance improvements

### DIFF
--- a/src/main/java/com/neovisionaries/bluetooth/ble/GattStatusCode.java
+++ b/src/main/java/com/neovisionaries/bluetooth/ble/GattStatusCode.java
@@ -16,8 +16,7 @@
 package com.neovisionaries.bluetooth.ble;
 
 
-import java.util.HashMap;
-import java.util.Map;
+import android.util.SparseArray;
 
 
 /**
@@ -267,22 +266,22 @@ public enum GattStatusCode
     ;
 
 
-    private static final Map<Integer, GattStatusCode> sValueToCodeMap;
+    private static final SparseArray<GattStatusCode> sValueToCodeMap;
     private final int mValue;
 
 
     static
     {
-        sValueToCodeMap = new HashMap<Integer, GattStatusCode>();
+        sValueToCodeMap = new SparseArray<>();
 
         for (GattStatusCode code : values())
         {
-            sValueToCodeMap.put(Integer.valueOf(code.getValue()), code);
+            sValueToCodeMap.put(code.getValue(), code);
         }
     }
 
 
-    private GattStatusCode(int value)
+    GattStatusCode(int value)
     {
         mValue = value;
     }
@@ -311,6 +310,6 @@ public enum GattStatusCode
      */
     public static GattStatusCode getByValue(int value)
     {
-        return sValueToCodeMap.get(Integer.valueOf(value));
+        return sValueToCodeMap.get(value);
     }
 }

--- a/src/main/java/com/neovisionaries/bluetooth/ble/StandardGattService.java
+++ b/src/main/java/com/neovisionaries/bluetooth/ble/StandardGattService.java
@@ -16,8 +16,8 @@
 package com.neovisionaries.bluetooth.ble;
 
 
-import java.util.HashMap;
-import java.util.Map;
+import android.util.SparseArray;
+
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -276,22 +276,21 @@ public enum StandardGattService
      * >Weight Scale</a> (0x181D).
      */
     WEIGHT_SCALE("Weight Scale", "weight_scale", 0x181D);
-    ;
 
 
     private static final String SPECIFICATION_TYPE_PREFIX = "org.bluetooth.service.";
     private static final Pattern UUID_PATTERN =
             Pattern.compile("0000([0-9a-fA-F]{4})[-]?0000[-]?1000[-]?8000[-]?00805[fF]9[bB]34[fF][bB]");
-    private static final Map<Integer, StandardGattService> sNumberToInstanceMap;
+    private static final SparseArray<StandardGattService> sNumberToInstanceMap;
 
 
     static
     {
-        sNumberToInstanceMap = new HashMap<Integer, StandardGattService>();
+        sNumberToInstanceMap = new SparseArray<>();
 
         for (StandardGattService instance : values())
         {
-            sNumberToInstanceMap.put(Integer.valueOf(instance.getNumber()), instance);
+            sNumberToInstanceMap.put(instance.getNumber(), instance);
         }
     }
 
@@ -305,7 +304,7 @@ public enum StandardGattService
     /**
      * The private constructor.
      */
-    private StandardGattService(String name, String shortType, int number)
+    StandardGattService(String name, String shortType, int number)
     {
         mName      = name;
         mShortType = shortType;
@@ -390,7 +389,7 @@ public enum StandardGattService
      */
     public static StandardGattService getByNumber(int number)
     {
-        return sNumberToInstanceMap.get(Integer.valueOf(number));
+        return sNumberToInstanceMap.get(number);
     }
 
 
@@ -414,7 +413,7 @@ public enum StandardGattService
 
         Matcher matcher = UUID_PATTERN.matcher(uuid);
 
-        if (matcher.matches() == false)
+        if (!matcher.matches())
         {
             return null;
         }

--- a/src/main/java/com/neovisionaries/bluetooth/ble/advertising/ADPayloadParser.java
+++ b/src/main/java/com/neovisionaries/bluetooth/ble/advertising/ADPayloadParser.java
@@ -16,11 +16,11 @@
 package com.neovisionaries.bluetooth.ble.advertising;
 
 
+import android.util.SparseArray;
+
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 
 /**
@@ -45,14 +45,14 @@ public class ADPayloadParser
     private static final ADPayloadParser sInstance = new ADPayloadParser();
 
 
-    private final Map<Integer, List<ADStructureBuilder>> mBuilders;
-    private final Map<Integer, List<ADManufacturerSpecificBuilder>> mMSBuilders;
+    private final SparseArray<List<ADStructureBuilder>> mBuilders;
+    private final SparseArray<List<ADManufacturerSpecificBuilder>> mMSBuilders;
 
 
     private ADPayloadParser()
     {
         // Builders for Manufacturer Specific Data.
-        mMSBuilders = new HashMap<Integer, List<ADManufacturerSpecificBuilder>>();
+        mMSBuilders = new SparseArray<>();
         registerManufacturerSpecificBuilder(0x004C, new MS004CBuilder());
         registerManufacturerSpecificBuilder(0x0105, new MS0105Builder());
         registerManufacturerSpecificBuilder(0x019A, new MS019ABuilder());
@@ -67,7 +67,7 @@ public class ADPayloadParser
         ServiceDataBuilder serviceDataBuilder = new ServiceDataBuilder();
 
         // Builders.
-        mBuilders = new HashMap<Integer, List<ADStructureBuilder>>();
+        mBuilders = new SparseArray<>();
 
         // 0x01: Flags
         registerBuilder(0x01, new FlagsBuilder());
@@ -163,7 +163,7 @@ public class ADPayloadParser
         }
 
         // Use the AD type as the key for the builder.
-        Integer key = Integer.valueOf(type);
+        Integer key = type;
 
         // Get the existing list of builders for the AD type.
         List<ADStructureBuilder> builders = mBuilders.get(key);
@@ -171,7 +171,7 @@ public class ADPayloadParser
         // If no builder has been registered for the AD type yet.
         if (builders == null)
         {
-            builders = new ArrayList<ADStructureBuilder>();
+            builders = new ArrayList<>();
             mBuilders.put(key, builders);
         }
 
@@ -204,7 +204,7 @@ public class ADPayloadParser
         }
 
         // Use the company ID as the key for the builder.
-        Integer key = Integer.valueOf(companyId);
+        Integer key = companyId;
 
         // Get the existing list of builders for the company ID.
         List<ADManufacturerSpecificBuilder> builders = mMSBuilders.get(key);
@@ -212,7 +212,7 @@ public class ADPayloadParser
         // If no builder has been registered for the company ID yet.
         if (builders == null)
         {
-            builders = new ArrayList<ADManufacturerSpecificBuilder>();
+            builders = new ArrayList<>();
             mMSBuilders.put(key, builders);
         }
 
@@ -436,7 +436,7 @@ public class ADPayloadParser
         }
 
         // List of AD structures.
-        List<ADStructure> list = new ArrayList<ADStructure>();
+        List<ADStructure> list = new ArrayList<>();
 
         // If parameters are wrong.
         if (offset < 0 || length < 0 || payload.length <= offset)
@@ -498,7 +498,7 @@ public class ADPayloadParser
     private ADStructure buildAds(int length, int type, byte[] data)
     {
         // Get the list of builders for the AD type.
-        List<ADStructureBuilder> builders = mBuilders.get(Integer.valueOf(type));
+        List<ADStructureBuilder> builders = mBuilders.get(type);
 
         // If builders for the AD type does not exist.
         if (builders == null)
@@ -540,7 +540,7 @@ public class ADPayloadParser
             int companyId = ((data[1] & 0xFF) << 8) | (data[0] & 0xFF);
 
             // Get the list of builders for the company ID.
-            List<ADManufacturerSpecificBuilder> builders = mMSBuilders.get(Integer.valueOf(companyId));
+            List<ADManufacturerSpecificBuilder> builders = mMSBuilders.get(companyId);
 
             // If builders for the company ID does not exist.
             if (builders == null)

--- a/src/main/java/com/neovisionaries/bluetooth/ble/advertising/IBeacon.java
+++ b/src/main/java/com/neovisionaries/bluetooth/ble/advertising/IBeacon.java
@@ -127,7 +127,7 @@ public class IBeacon extends ADManufacturerSpecific
         long lsbits = uuid.getLeastSignificantBits();
 
         byte[] data = getData();
-        data[UUID_INDEX +  0] = (byte)((msbits >> 56) & 0xFF);
+        data[UUID_INDEX] = (byte)((msbits >> 56) & 0xFF);
         data[UUID_INDEX +  1] = (byte)((msbits >> 48) & 0xFF);
         data[UUID_INDEX +  2] = (byte)((msbits >> 40) & 0xFF);
         data[UUID_INDEX +  3] = (byte)((msbits >> 32) & 0xFF);
@@ -142,7 +142,7 @@ public class IBeacon extends ADManufacturerSpecific
         data[UUID_INDEX + 12] = (byte)((lsbits >> 24) & 0xFF);
         data[UUID_INDEX + 13] = (byte)((lsbits >> 16) & 0xFF);
         data[UUID_INDEX + 14] = (byte)((lsbits >>  8) & 0xFF);
-        data[UUID_INDEX + 15] = (byte)((lsbits >>  0) & 0xFF);
+        data[UUID_INDEX + 15] = (byte)((lsbits) & 0xFF);
     }
 
 

--- a/src/main/java/com/neovisionaries/bluetooth/ble/advertising/MSBuilder.java
+++ b/src/main/java/com/neovisionaries/bluetooth/ble/advertising/MSBuilder.java
@@ -17,6 +17,7 @@ package com.neovisionaries.bluetooth.ble.advertising;
 
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 
@@ -25,21 +26,12 @@ import java.util.List;
  */
 public class MSBuilder implements ADManufacturerSpecificBuilder
 {
-    private final List<ADManufacturerSpecificBuilder> mBuilders =
-        new ArrayList<ADManufacturerSpecificBuilder>();
-
-
-    public MSBuilder()
-    {
-    }
+    private final List<ADManufacturerSpecificBuilder> mBuilders = new ArrayList<>();
 
 
     public MSBuilder(ADManufacturerSpecificBuilder... builders)
     {
-        for (ADManufacturerSpecificBuilder builder : builders)
-        {
-            mBuilders.add(builder);
-        }
+        Collections.addAll(mBuilders, builders);
     }
 
 

--- a/src/main/java/com/neovisionaries/bluetooth/ble/advertising/Ucode.java
+++ b/src/main/java/com/neovisionaries/bluetooth/ble/advertising/Ucode.java
@@ -16,6 +16,9 @@
 package com.neovisionaries.bluetooth.ble.advertising;
 
 
+import com.neovisionaries.bluetooth.ble.util.Bytes;
+
+import java.util.Arrays;
 import java.util.regex.Pattern;
 
 
@@ -49,8 +52,6 @@ public class Ucode extends ADManufacturerSpecific
     private static final int POWER_INDEX   = 20;
     private static final int COUNT_INDEX   = 21;
     private static final int LOW_BATTERY_BIT = 0x20;
-    private static final String UCODE_FORMAT
-        = "%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X";
     private static final String STRING_FORMAT
         = "ucode(Version=%d,Ucode=%s,Status=%d,BatteryLow=%s,Interval=%d,Power=%d,Count=%d)";
     private static final Pattern UCODE_PATTERN = Pattern.compile("^[0-9A-Fa-f]{32}$");
@@ -183,7 +184,7 @@ public class Ucode extends ADManufacturerSpecific
             throw new IllegalArgumentException("'ucode' is null.");
         }
 
-        if (UCODE_PATTERN.matcher(ucode).matches() == false)
+        if (!UCODE_PATTERN.matcher(ucode).matches())
         {
             throw new IllegalArgumentException("The format of 'ucode' is wrong: " + ucode);
         }
@@ -499,16 +500,7 @@ public class Ucode extends ADManufacturerSpecific
 
     private String buildUcode(byte[] data)
     {
-        // Ucode is packed in the little endian order.
-        return String.format(UCODE_FORMAT,
-            data[UCODE_INDEX + 15] & 0xFF, data[UCODE_INDEX + 14] & 0xFF,
-            data[UCODE_INDEX + 13] & 0xFF, data[UCODE_INDEX + 12] & 0xFF,
-            data[UCODE_INDEX + 11] & 0xFF, data[UCODE_INDEX + 10] & 0xFF,
-            data[UCODE_INDEX +  9] & 0xFF, data[UCODE_INDEX +  8] & 0xFF,
-            data[UCODE_INDEX +  7] & 0xFF, data[UCODE_INDEX +  6] & 0xFF,
-            data[UCODE_INDEX +  5] & 0xFF, data[UCODE_INDEX +  4] & 0xFF,
-            data[UCODE_INDEX +  3] & 0xFF, data[UCODE_INDEX +  2] & 0xFF,
-            data[UCODE_INDEX +  1] & 0xFF, data[UCODE_INDEX +  0] & 0xFF);
+        return Bytes.toLittleEndianHexString(Arrays.copyOfRange(data, 0, 16), true);
     }
 
 

--- a/src/main/java/com/neovisionaries/bluetooth/ble/util/Bytes.java
+++ b/src/main/java/com/neovisionaries/bluetooth/ble/util/Bytes.java
@@ -16,6 +16,10 @@
 package com.neovisionaries.bluetooth.ble.util;
 
 
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.UUID;
+
 /**
  * Utility for byte arrays.
  *
@@ -37,10 +41,8 @@ public class Bytes
      */
     public static int parseBE2BytesAsInt(byte[] data, int offset)
     {
-        int value = ((data[offset + 0] & 0xFF) << 8)
-                  | ((data[offset + 1] & 0xFF) << 0);
-
-        return value;
+        return ((data[offset] & 0xFF) << 8)
+                  | ((data[offset + 1] & 0xFF));
     }
 
 
@@ -49,12 +51,10 @@ public class Bytes
      */
     public static int parseBE4BytesAsInt(byte[] data, int offset)
     {
-        int value = ((data[offset + 0] & 0xFF) << 24)
+        return ((data[offset] & 0xFF) << 24)
                   | ((data[offset + 1] & 0xFF) << 16)
                   | ((data[offset + 2] & 0xFF) <<  8)
                   | ((data[offset + 3] & 0xFF));
-
-        return value;
     }
 
 
@@ -63,12 +63,11 @@ public class Bytes
      */
     public static long parseBE4BytesAsUnsigned(byte[] data, int offset)
     {
-        long value = ((long)(data[offset + 0] & 0xFF) << 24)
+
+        return ((long)(data[offset] & 0xFF) << 24)
                    | ((long)(data[offset + 1] & 0xFF) << 16)
                    | ((long)(data[offset + 2] & 0xFF) <<  8)
-                   | ((long)(data[offset + 3] & 0xFF) <<  0);
-
-        return value;
+                   | ((long)(data[offset + 3] & 0xFF));
     }
 
 
@@ -116,6 +115,122 @@ public class Bytes
         }
 
         return new String(chars);
+    }
+
+    /**
+     * Convert a byte array to a hex string, in little endian order.
+     *
+     * @param data
+     *         An input byte array.
+     *
+     * @param upper
+     *         {@code true} to generate a upper-case hex string.
+     *         {@code false} to generate a lower-case hex string.
+     *
+     * @return
+     *         A hex string. if {@code data} is {@code null},
+     *         {@code null} is returned.
+     */
+    public static String toLittleEndianHexString(byte[] data, boolean upper)
+    {
+        if (data == null)
+        {
+            return null;
+        }
+
+        char[] table = (upper ? UPPER_HEX_CHARS : LOWER_HEX_CHARS);
+        char[] chars = new char[data.length * 2];
+
+        for (int i = data.length - 1; i >= 0; i--)
+        {
+            chars[i * 2    ] = table[ (data[i] & 0xF0) >> 4 ];
+            chars[i * 2 + 1] = table[ (data[i] & 0x0F)      ];
+        }
+
+        return new String(chars);
+    }
+
+
+    /**
+     * Convert a hex string to a byte array.
+     *
+     * @param s
+     *         Input {@code String}.
+     *
+     * @return
+     *         Input as a {@code byte[]}.
+     */
+    public static byte[] hexStringToByteArray(String s)
+    {
+        int len = s.length();
+        byte[] data = new byte[len / 2];
+        for (int i = 0; i < len; i += 2)
+        {
+            data[i / 2] = (byte) ((Character.digit(s.charAt(i), 16) << 4)
+                    + Character.digit(s.charAt(i+1), 16));
+        }
+        return data;
+    }
+
+
+    /**
+     * Convert a byte array to an UUID.
+     *
+     * @param uuidData
+     *         {@code byte[]} to convert.
+     *
+     * @param littleEndian
+     *         Use little endian?
+     *
+     * @return
+     *         A new UUID.
+     */
+    public static UUID toUUID(byte[] uuidData, boolean littleEndian)
+    {
+        ByteBuffer bb = ByteBuffer.wrap(uuidData)
+                .order(littleEndian ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
+        return new UUID(bb.getLong(), bb.getLong());
+    }
+
+
+    /**
+     * Concatenate two byte arrays.
+     *
+     * @param a
+     *         First byte array.
+     *
+     * @param b
+     *         Second byte array.
+     *
+     * @return
+     *         A new byte array, a + b.
+     */
+    public static byte[] concat(byte[] a, byte[] b)
+    {
+        int aLen = a.length;
+        int bLen = b.length;
+        byte[] c = new byte[aLen + bLen];
+        System.arraycopy(a, 0, c, 0, aLen);
+        System.arraycopy(b, 0, c, aLen, bLen);
+        return c;
+    }
+
+
+    /**
+     * Reverse the order of a byte array.
+     *
+     * @param a
+     *         Byte array you wish to reverse.
+     */
+    public static void reverse(byte[] a)
+    {
+        for(int i = 0; i < a.length / 2; i++)
+        {
+            int from = a.length - i - 1;
+            byte temp = a[i];
+            a[i] = a[from];
+            a[from] = temp;
+        }
     }
 
 

--- a/src/main/java/com/neovisionaries/bluetooth/ble/util/UUIDCreator.java
+++ b/src/main/java/com/neovisionaries/bluetooth/ble/util/UUIDCreator.java
@@ -16,6 +16,7 @@
 package com.neovisionaries.bluetooth.ble.util;
 
 
+import java.util.Arrays;
 import java.util.UUID;
 
 
@@ -29,14 +30,7 @@ public class UUIDCreator
     /**
      * Bluetooth Base UUID used to build a complete UUID from a 16-bit/32-bit UUID.
      */
-    private static final String BASE_UUID_FORMAT =
-        "%02x%02x%02x%02x-0000-1000-8000-00805f9b34fb";
-
-    /**
-     * Generic UUID format that can be parsed by UUID.fromString(String).
-     */
-    private static final String GENERIC_UUID_FORMAT =
-        "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x";
+    private static final byte[] BASE_UUID = Bytes.hexStringToByteArray("00001000800000805f9b34fb");
 
 
     private UUIDCreator()
@@ -134,20 +128,12 @@ public class UUIDCreator
             return null;
         }
 
-        int v2, v3;
-
+        byte[] uuidData = Arrays.copyOfRange(data, offset, offset + 2);
         if (littleEndian)
         {
-            v2 = data[offset + 1] & 0xFF;
-            v3 = data[offset + 0] & 0xFF;
+            Bytes.reverse(uuidData);
         }
-        else
-        {
-            v2 = data[offset + 0] & 0xFF;
-            v3 = data[offset + 1] & 0xFF;
-        }
-
-        return fromBase(0, 0, v2, v3);
+        return Bytes.toUUID(Bytes.concat(Bytes.concat(new byte[] { 0, 0 }, uuidData), BASE_UUID), false);
     }
 
 
@@ -241,30 +227,12 @@ public class UUIDCreator
             return null;
         }
 
-        int v0, v1, v2, v3;
-
+        byte[] uuidData = Arrays.copyOfRange(data, offset, offset + 4);
         if (littleEndian)
         {
-            v0 = data[offset + 3] & 0xFF;
-            v1 = data[offset + 2] & 0xFF;
-            v2 = data[offset + 1] & 0xFF;
-            v3 = data[offset + 0] & 0xFF;
+            Bytes.reverse(uuidData);
         }
-        else
-        {
-            v0 = data[offset + 0] & 0xFF;
-            v1 = data[offset + 1] & 0xFF;
-            v2 = data[offset + 2] & 0xFF;
-            v3 = data[offset + 3] & 0xFF;
-        }
-
-        return fromBase(v0, v1, v2, v3);
-    }
-
-
-    private static UUID fromBase(int v0, int v1, int v2, int v3)
-    {
-        return UUID.fromString(String.format(BASE_UUID_FORMAT, v0, v1, v2, v3));
+        return Bytes.toUUID(Bytes.concat(uuidData, BASE_UUID), false);
     }
 
 
@@ -360,33 +328,7 @@ public class UUIDCreator
             return null;
         }
 
-        String uuid;
-
-        if (littleEndian)
-        {
-            uuid = String.format(GENERIC_UUID_FORMAT,
-                data[offset + 15] & 0xFF, data[offset + 14] & 0xFF,
-                data[offset + 13] & 0xFF, data[offset + 12] & 0xFF,
-                data[offset + 11] & 0xFF, data[offset + 10] & 0xFF,
-                data[offset +  9] & 0xFF, data[offset +  8] & 0xFF,
-                data[offset +  7] & 0xFF, data[offset +  6] & 0xFF,
-                data[offset +  5] & 0xFF, data[offset +  4] & 0xFF,
-                data[offset +  3] & 0xFF, data[offset +  2] & 0xFF,
-                data[offset +  1] & 0xFF, data[offset +  0] & 0xFF);
-        }
-        else
-        {
-            uuid = String.format(GENERIC_UUID_FORMAT,
-                data[offset +  0] & 0xFF, data[offset +  1] & 0xFF,
-                data[offset +  2] & 0xFF, data[offset +  3] & 0xFF,
-                data[offset +  4] & 0xFF, data[offset +  5] & 0xFF,
-                data[offset +  6] & 0xFF, data[offset +  7] & 0xFF,
-                data[offset +  8] & 0xFF, data[offset +  9] & 0xFF,
-                data[offset + 10] & 0xFF, data[offset + 11] & 0xFF,
-                data[offset + 12] & 0xFF, data[offset + 13] & 0xFF,
-                data[offset + 14] & 0xFF, data[offset + 15] & 0xFF);
-        }
-
-        return UUID.fromString(uuid);
+        byte[] uuidData = Arrays.copyOfRange(data, offset, offset + 16);
+        return Bytes.toUUID(uuidData, littleEndian);
     }
 }


### PR DESCRIPTION
Hello!
I ran into some performance problems in your otherwise fantastic library, and decided to look into them.

Here's an image of a method trace of the standard 1.8 version of your library, running on a Nexus 5X device, with nv-bluetooth highlighted with blue. Around 99% of the CPU time for the library is used for UUIDCreator's use of String.parse.
![first](https://user-images.githubusercontent.com/8450599/29881344-fda5dc9c-8db2-11e7-9e53-285934789df9.PNG)

Here's an image after the changes.
![fourth](https://user-images.githubusercontent.com/8450599/29881352-00a6e0ee-8db3-11e7-9fed-2f7555b0d078.PNG)

Other changes include minor semantic changes suggested by Android Studio Lint.